### PR TITLE
CI integration and update go.mod.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Ignore everything
+*
+
+# But not these files...
+!*.go
+!go.sum
+!go.mod
+
+!README.md
+!LICENSE
+
+# ...even if they are in subdirectories
+!*/

--- a/.github/main.yaml
+++ b/.github/main.yaml
@@ -1,0 +1,40 @@
+name: Docker Build
+on:
+  push:
+    branches:
+      - "main"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get Short Commit Hash
+        id: commit-hash
+        run: echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/falco-gpt:${{ env.GITHUB_SHA_SHORT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/falco-gpt:latest

--- a/.github/main.yaml
+++ b/.github/main.yaml
@@ -1,8 +1,8 @@
 name: Docker Build
 on:
   push:
-    branches:
-      - "main"
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM cgr.dev/chainguard/go:latest as builder
 WORKDIR /opt
 COPY . .
 RUN go mod download
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./falco-gpt .
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -buildid=" -o ./falco-gpt .
 
 FROM cgr.dev/chainguard/static:latest
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.20.2-alpine as builder
+FROM cgr.dev/chainguard/go:latest as builder
 WORKDIR /opt
 COPY . .
 RUN go mod download
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./falco-gpt .
 
-FROM alpine:3.17
+FROM cgr.dev/chainguard/static:latest
 WORKDIR /app
 COPY --from=builder /opt/falco-gpt /app/falco-gpt
 CMD [ "./falco-gpt" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.20.2-alpine as builder
+WORKDIR /opt
+COPY . .
+RUN go mod download
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./falco-gpt .
+
+FROM alpine:3.17
+WORKDIR /app
+COPY --from=builder /opt/falco-gpt /app/falco-gpt
+CMD [ "./falco-gpt" ]

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module falco-gpt
+module github.com/Dentrax/falco-gpt
 
 go 1.20
 


### PR DESCRIPTION
Added Dockerfile and workflow to build and push to dockerhub but since you are using dockerhub `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` should be set in repository secrets. 

Also updated go.mod to make installable using `go install...`. See error:

```bash
~ go install github.com/Dentrax/falco-gpt@latest                                                                                                                                                               
go: github.com/Dentrax/falco-gpt@latest: github.com/Dentrax/falco-gpt@v0.1.0: parsing go.mod:
	module declares its path as: falco-gpt
	        but was required as: github.com/Dentrax/falco-gpt
```

Related with: #1 